### PR TITLE
@Async + @Transactional 사용 시 데이터 불일치 문제 해결

### DIFF
--- a/src/main/java/com/project/InsightPrep/domain/question/event/AnswerSavedEvent.java
+++ b/src/main/java/com/project/InsightPrep/domain/question/event/AnswerSavedEvent.java
@@ -1,0 +1,6 @@
+package com.project.InsightPrep.domain.question.event;
+
+import com.project.InsightPrep.domain.question.entity.Answer;
+
+public record AnswerSavedEvent(Answer answer) {
+}

--- a/src/main/java/com/project/InsightPrep/domain/question/event/FeedbackEventListener.java
+++ b/src/main/java/com/project/InsightPrep/domain/question/event/FeedbackEventListener.java
@@ -1,0 +1,44 @@
+package com.project.InsightPrep.domain.question.event;
+
+import com.project.InsightPrep.domain.question.dto.response.FeedbackResponse;
+import com.project.InsightPrep.domain.question.entity.Answer;
+import com.project.InsightPrep.domain.question.entity.AnswerFeedback;
+import com.project.InsightPrep.domain.question.mapper.FeedbackMapper;
+import com.project.InsightPrep.global.gpt.prompt.PromptFactory;
+import com.project.InsightPrep.global.gpt.service.GptResponseType;
+import com.project.InsightPrep.global.gpt.service.GptService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class FeedbackEventListener {
+
+    private final GptService gptService;
+    private final FeedbackMapper feedbackMapper;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleAnswerSaved(AnswerSavedEvent event) {
+        Answer answer = event.answer();
+
+        String question = answer.getQuestion().getContent();
+        String userAnswer = answer.getContent();
+
+        FeedbackResponse gptResult = gptService.callOpenAI(PromptFactory.forFeedbackGeneration(question, userAnswer), 1000, 0.4, GptResponseType.FEEDBACK);
+        AnswerFeedback feedback = AnswerFeedback.builder()
+                .answer(answer)
+                .score(gptResult.getScore())
+                .modelAnswer(gptResult.getModelAnswer())
+                .improvement(gptResult.getImprovement())
+                .build();
+
+        feedbackMapper.insertFeedback(feedback);
+        log.info("Feedback saved for Answer id = {}", answer.getId());
+    }
+}

--- a/src/main/java/com/project/InsightPrep/domain/question/service/impl/AnswerServiceImpl.java
+++ b/src/main/java/com/project/InsightPrep/domain/question/service/impl/AnswerServiceImpl.java
@@ -7,6 +7,7 @@ import com.project.InsightPrep.domain.question.dto.response.PreviewResponse;
 import com.project.InsightPrep.domain.question.entity.Answer;
 import com.project.InsightPrep.domain.question.entity.AnswerStatus;
 import com.project.InsightPrep.domain.question.entity.Question;
+import com.project.InsightPrep.domain.question.event.AnswerSavedEvent;
 import com.project.InsightPrep.domain.question.exception.QuestionErrorCode;
 import com.project.InsightPrep.domain.question.exception.QuestionException;
 import com.project.InsightPrep.domain.question.mapper.AnswerMapper;
@@ -16,6 +17,7 @@ import com.project.InsightPrep.domain.question.service.FeedbackService;
 import com.project.InsightPrep.global.auth.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +30,7 @@ public class AnswerServiceImpl implements AnswerService {
     private final QuestionMapper questionMapper;
     private final AnswerMapper answerMapper;
     private final FeedbackService feedbackService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional
@@ -43,7 +46,8 @@ public class AnswerServiceImpl implements AnswerService {
 
         questionMapper.updateStatus(questionId, AnswerStatus.ANSWERED.name());
         answerMapper.insertAnswer(answer);
-        feedbackService.saveFeedback(answer);
+        //feedbackService.saveFeedback(answer);
+        eventPublisher.publishEvent(new AnswerSavedEvent(answer));
         return AnswerResponse.AnswerDto.builder()
                 .answerId(answer.getId()).build();
     }

--- a/src/main/java/com/project/InsightPrep/domain/question/service/impl/FeedbackServiceImpl.java
+++ b/src/main/java/com/project/InsightPrep/domain/question/service/impl/FeedbackServiceImpl.java
@@ -30,9 +30,6 @@ public class FeedbackServiceImpl implements FeedbackService {
         String userAnswer = answer.getContent();
 
         FeedbackResponse gptResult = gptService.callOpenAI(PromptFactory.forFeedbackGeneration(question, userAnswer), 1000, 0.4, GptResponseType.FEEDBACK);
-        System.out.println(gptResult.getScore());
-        System.out.println(gptResult.getImprovement());
-        System.out.println(gptResult.getModelAnswer());
         AnswerFeedback feedback = AnswerFeedback.builder()
                 .answer(answer)
                 .score(gptResult.getScore())

--- a/src/test/java/com/project/InsightPrep/domain/question/event/FeedbackEventListenerTest.java
+++ b/src/test/java/com/project/InsightPrep/domain/question/event/FeedbackEventListenerTest.java
@@ -1,0 +1,110 @@
+package com.project.InsightPrep.domain.question.event;
+
+import com.project.InsightPrep.domain.question.dto.response.FeedbackResponse;
+import com.project.InsightPrep.domain.question.entity.Answer;
+import com.project.InsightPrep.domain.question.entity.AnswerFeedback;
+import com.project.InsightPrep.domain.question.entity.Question;
+import com.project.InsightPrep.domain.question.exception.QuestionErrorCode;
+import com.project.InsightPrep.domain.question.exception.QuestionException;
+import com.project.InsightPrep.domain.question.mapper.FeedbackMapper;
+import com.project.InsightPrep.global.gpt.service.GptResponseType;
+import com.project.InsightPrep.global.gpt.service.GptService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class FeedbackEventListenerTest {
+
+    @Mock
+    private GptService gptService;
+
+    @Mock
+    private FeedbackMapper feedbackMapper;
+
+    @InjectMocks
+    private FeedbackEventListener feedbackEventListener;
+
+    private Answer answer;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        Question question = Question.builder()
+                .id(1L)
+                .content("OS에서 스레드와 프로세스의 차이점은?")
+                .build();
+
+        answer = Answer.builder()
+                .id(10L)
+                .question(question)
+                .content("스레드는 프로세스 내 실행 단위입니다.")
+                .build();
+    }
+
+    @Test
+    @DisplayName("정상적인 AnswerSavedEvent가 주어지면 Feedback이 저장된다")
+    void handleAnswerSaved_success() {
+        // given
+        FeedbackResponse mockResponse = FeedbackResponse.builder()
+                .score(5)
+                .modelAnswer("모델 답변")
+                .improvement("개선 필요")
+                .build();
+        when(gptService.callOpenAI(anyList(), anyInt(), anyDouble(), eq(GptResponseType.FEEDBACK)))
+                .thenReturn(mockResponse);
+
+        AnswerSavedEvent event = new AnswerSavedEvent(answer);
+
+        // when
+        feedbackEventListener.handleAnswerSaved(event);
+
+        // then
+        ArgumentCaptor<AnswerFeedback> captor = ArgumentCaptor.forClass(AnswerFeedback.class);
+        verify(feedbackMapper, times(1)).insertFeedback(captor.capture());
+
+        AnswerFeedback saved = captor.getValue();
+        assertThat(saved.getAnswer()).isEqualTo(answer);
+        assertThat(saved.getScore()).isEqualTo(5);
+        assertThat(saved.getModelAnswer()).isEqualTo("모델 답변");
+        assertThat(saved.getImprovement()).isEqualTo("개선 필요");
+    }
+
+    @Test
+    @DisplayName("Answer가 null이면 예외가 발생한다")
+    void handleAnswerSaved_nullAnswer() {
+        // given
+        AnswerSavedEvent event = new AnswerSavedEvent(null);
+
+        // when & then
+        assertThrows(QuestionException.class, () -> feedbackEventListener.handleAnswerSaved(event));
+        verify(feedbackMapper, never()).insertFeedback(any());
+    }
+
+    @Test
+    @DisplayName("Answer에 Question 또는 content가 null이면 예외가 발생한다")
+    void handleAnswerSaved_invalidAnswer() {
+        Answer invalidAnswer = Answer.builder()
+                .id(20L)
+                .question(null) // 질문 없음
+                .content(null) // 답변 없음
+                .build();
+
+        AnswerSavedEvent event = new AnswerSavedEvent(invalidAnswer);
+
+
+
+
+        assertThrows(QuestionException.class, () -> feedbackEventListener.handleAnswerSaved(event));
+        verify(feedbackMapper, never()).insertFeedback(any());
+    }
+}


### PR DESCRIPTION
### **User description**
## 관련 이슈 (Related Issues)

<!--
  이 PR과 관련된 이슈를 링크하세요. GitHub의 키워드를 사용하여 자동으로 이슈를 연결할 수 있습니다.
  예: Closes #123, Fixes #456, Resolves #789, Related to #2
-->

- Related to #19 

### 🚀 PR 개요

Answer–Feedback 비동기 처리 구조를 리팩토링하여 데이터 정합성을 보장하고 성능을 유지했습니다.

### 📌 변경 배경
- 기존 구조는 AnswerService.saveAnswer() 안에서 `@Async` `@Transactional`이 적용된 FeedbackService.saveFeedback()을 직접 호출하는 방식이었습니다.
- 이 경우 saveAnswer() 트랜잭션이 롤백되더라도, saveFeedback()은 별도 트랜잭션에서 실행되어 Feedback이 DB에 커밋되는 문제가 있었습니다.
- 현재는 FK 제약조건 덕분에 “Answer 없는 Feedback”이 DB 레벨에서 차단되지만, 이는 단순 방어일 뿐 애플리케이션 레벨에서는 구조적으로 불완전했습니다.

### 🔍 원인 분석
Spring의 `@Async`는 별도의 스레드와 별도의 트랜잭션에서 실행됩니다. 따라서 AnswerService.saveAnswer()에서 예외 발생 시 Answer와 Question은 롤백되지만, Feedback은 이미 커밋되어 데이터 불일치가 발생할 수 있었습니다.

✅ 해결 과정
- 트랜잭션 커밋 후에만 Feedback 생성을 실행할 수 있도록 이벤트 기반 구조로 변경했습니다.
  - AnswerSavedEvent를 발행하도록 수정
  - `@TransactionalEventListener(phase = AFTER_COMMIT)`에서만 Feedback 생성이 실행되도록 보장
- GPT 호출은 여전히 `@Async`로 비동기 처리하여 서비스 응답 속도 유지
- 이를 통해 Answer가 실제 DB에 커밋된 이후에만 Feedback 생성이 실행되도록 보장했습니다.

🎯 결과
- 데이터 정합성 보장: Answer 없는 Feedback이 생성될 수 있는 가능성을 원천 차단
- 성능 유지: Feedback 생성은 여전히 비동기 처리되어 사용자 응답 속도에는 영향 없음
- 안정적 아키텍처 확보: FK 제약조건 의존에서 벗어나 애플리케이션 레벨에서도 완전한 일관성 확보


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- 이벤트 기반으로 피드백 생성 전환

- 트랜잭션 커밋 후 비동기 처리 보장

- 콘솔 로그 제거 및 예외 처리 추가

- 단위 테스트 추가 및 검증 강화


___

### Diagram Walkthrough


```mermaid
flowchart LR
  AnswerService["Answer 저장 (트랜잭션)"]
  Event["AnswerSavedEvent 발행"]
  TxCommit["트랜잭션 커밋"]
  Listener["FeedbackEventListener (@Async, AFTER_COMMIT)"]
  GPT["GptService 호출"]
  Persist["FeedbackMapper.insertFeedback"]

  AnswerService -- "publishEvent" --> Event
  Event -- "AFTER_COMMIT" --> TxCommit
  TxCommit -- "트리거" --> Listener
  Listener -- "질문/답변 검증" --> GPT
  GPT -- "FeedbackResponse" --> Persist
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AnswerSavedEvent.java</strong><dd><code>Answer 저장 이벤트 객체 도입</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/project/InsightPrep/domain/question/event/AnswerSavedEvent.java

- `AnswerSavedEvent` 레코드 추가
- Answer 엔티티를 이벤트 페이로드로 보관


</details>


  </td>
  <td><a href="https://github.com/sgn07124/InsightPrep/pull/29/files#diff-daf5cffddd899a4069bb56dc2f8e0b1b4c9f97606b89c8d631964f6e86c929ac">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FeedbackEventListener.java</strong><dd><code>트랜잭션 후 비동기 피드백 생성 리스너</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/project/InsightPrep/domain/question/event/FeedbackEventListener.java

<ul><li>AFTER_COMMIT 이벤트 리스너 추가<br> <li> @Async로 GPT 호출 비동기화<br> <li> Answer/Question null 검증 및 예외 처리<br> <li> Feedback 생성 후 매퍼로 저장</ul>


</details>


  </td>
  <td><a href="https://github.com/sgn07124/InsightPrep/pull/29/files#diff-25539e8077a445034555d3060f97b5b8aa55b8c849edeb7c5e0319f3187d547b">+49/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AnswerServiceImpl.java</strong><dd><code>서비스에서 이벤트 발행으로 피드백 분리</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/project/InsightPrep/domain/question/service/impl/AnswerServiceImpl.java

<ul><li><code>ApplicationEventPublisher</code> 주입<br> <li> 직접 호출 제거 후 <code>AnswerSavedEvent</code> 발행<br> <li> 트랜잭션 내 Answer 저장 후 이벤트 퍼블리시</ul>


</details>


  </td>
  <td><a href="https://github.com/sgn07124/InsightPrep/pull/29/files#diff-0ebed7a8c4fa373abced95a3ce04df2e5b730ee1882a33bdadab25cf3b20b8d1">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FeedbackServiceImpl.java</strong><dd><code>디버그 출력 제거로 정리</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/project/InsightPrep/domain/question/service/impl/FeedbackServiceImpl.java

- 불필요한 System.out 제거
- 로직은 기존과 동일 유지


</details>


  </td>
  <td><a href="https://github.com/sgn07124/InsightPrep/pull/29/files#diff-fbfb0851fbf3f54e68535bb8def70a1e0c12c51aa009c52ced74eb96afbf38c0">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FeedbackEventListenerTest.java</strong><dd><code>이벤트 리스너 단위 테스트 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/project/InsightPrep/domain/question/event/FeedbackEventListenerTest.java

<ul><li>정상 플로우에서 Feedback 저장 검증<br> <li> null/invalid Answer 예외 검증<br> <li> GPT 호출 모킹 및 매퍼 캡처 확인</ul>


</details>


  </td>
  <td><a href="https://github.com/sgn07124/InsightPrep/pull/29/files#diff-c2c7f63fb2b12ae574cd342dd3e224859f14b41196340a024f106bba9d937164">+110/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AnswerServiceImplTest.java</strong><dd><code>Answer 서비스 테스트를 이벤트 기반으로 수정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/project/InsightPrep/domain/question/service/impl/AnswerServiceImplTest.java

<ul><li>이벤트 퍼블리시 검증으로 테스트 수정<br> <li> <code>AnswerSavedEvent</code> 캡처 및 값 검증<br> <li> 비동기 고려해 Awaitility로 검증</ul>


</details>


  </td>
  <td><a href="https://github.com/sgn07124/InsightPrep/pull/29/files#diff-f6405bc7f464fb4638044dce789c5c340c81a9cf2e58e334c940e15c02f04684">+40/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

